### PR TITLE
Fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 dist
+/.cabal-sandbox
+/cabal.sandbox.config

--- a/README.md
+++ b/README.md
@@ -28,8 +28,18 @@ Please see the [wiki](https://github.com/Concelo/concelo/wiki) for details.
 Build Notes
 -----------
 
-  sudo apt-get install ghc-prof libghc-mtl-prof libghc-text-prof libghc-parsec3-prof libghc-network-prof
+```
+
+  # First, install ghc+cabal:
+    # For linux:
+    sudo apt-get install ghc-prof libghc-mtl-prof libghc-text-prof libghc-parsec3-prof libghc-network-prof
+
+    # For mac:
+    brew install cabal-install
+
+  # Make a cabal sandbox so as to not pollute the global package store
   cabal sandbox init
-  cabal configure --enable-library-profiling --enable-executable-profiling --enable-tests
-  cabal install --only-dependencies
+
+  # Finally, compile & run the tests:
   cabal test --show-details=streaming
+```

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+  timezone:
+    America/Denver
+  cache_directories:
+    - ".cabal-sandbox"
+  ghc:
+    version: 7.10.2
+test:
+  override:
+    - cabal test --show-details=streaming

--- a/src/Database/Concelo/BiTrie.hs
+++ b/src/Database/Concelo/BiTrie.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE RankNTypes #-}
 module Database.Concelo.BiTrie
   ( BiTrie()

--- a/src/Database/Concelo/BiTrie.hs
+++ b/src/Database/Concelo/BiTrie.hs
@@ -17,7 +17,6 @@ module Database.Concelo.BiTrie
   , find ) where
 
 import Data.Maybe (fromMaybe)
-import Data.Functor ((<$>))
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Database.Concelo.Trie as T

--- a/src/Database/Concelo/Bytes.hs
+++ b/src/Database/Concelo/Bytes.hs
@@ -11,7 +11,6 @@ module Database.Concelo.Bytes
   , prefix ) where
 
 import Data.Bits ((.&.))
-import Data.Functor ((<$>))
 
 import qualified Database.Concelo.Control as Co
 import qualified Data.ByteString as BS

--- a/src/Database/Concelo/Chunks.hs
+++ b/src/Database/Concelo/Chunks.hs
@@ -6,7 +6,6 @@ import Database.Concelo.Control (badForest, maybeToAction,
                                  Exception(Exception))
 
 import Control.Monad (foldM)
-import Data.Functor ((<$>))
 
 import qualified Database.Concelo.Protocol as Pr
 import qualified Database.Concelo.Trie as T

--- a/src/Database/Concelo/Control.hs
+++ b/src/Database/Concelo/Control.hs
@@ -54,8 +54,6 @@ module Database.Concelo.Control
 
 -- import Debug.Trace
 
-import Data.Functor ((<$>))
-
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Char as C
 import qualified Control.Lens as L

--- a/src/Database/Concelo/Crypto.hs
+++ b/src/Database/Concelo/Crypto.hs
@@ -29,9 +29,6 @@ module Database.Concelo.Crypto
   , verify
   , hash ) where
 
-import Data.Functor ((<$>))
-import Data.Foldable (Foldable())
-
 import qualified Crypto.Error as E
 import qualified Crypto.Random as R
 import qualified Crypto.Cipher.Types as CT

--- a/src/Database/Concelo/Deserializer.hs
+++ b/src/Database/Concelo/Deserializer.hs
@@ -12,7 +12,6 @@ module Database.Concelo.Deserializer
   , deserialize ) where
 
 import Database.Concelo.Control (get)
-import Data.Functor ((<$>))
 import Prelude hiding (null)
 import Database.Concelo.Misc (null)
 import Data.Maybe (fromMaybe)

--- a/src/Database/Concelo/Ignis.hs
+++ b/src/Database/Concelo/Ignis.hs
@@ -32,7 +32,6 @@ import qualified Database.Concelo.Control as Co
 
 import Database.Concelo.Control (get, set, with, lend, exception, run)
 
-import Data.Functor ((<$>))
 import Data.Maybe (fromMaybe)
 import Control.Monad (foldM, when)
 

--- a/src/Database/Concelo/Map.hs
+++ b/src/Database/Concelo/Map.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 module Database.Concelo.Map
   ( Map()
   , empty
@@ -27,10 +26,10 @@ import Data.Foldable (Foldable(foldr))
 
 newtype Map k v = Map { run :: V.VMap k v }
 
-instance (Show k, Show v) => Show (Map k v) where
+instance {-# OVERLAPPABLE #-} (Show k, Show v) => Show (Map k v) where
   show = show . run
 
-instance Show v => Show (Map BS.ByteString v) where
+instance {-# OVERLAPPABLE #-} Show v => Show (Map BS.ByteString v) where
   show = show . run
 
 instance Ord k => Functor (Map k) where

--- a/src/Database/Concelo/Path.hs
+++ b/src/Database/Concelo/Path.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 module Database.Concelo.Path
   ( Path(Path)
   , leaf
@@ -25,10 +24,10 @@ import qualified Database.Concelo.Bytes as B
 data Path k v = Path { getPathKeys :: [k]
                      , getPathValue :: v } deriving (Eq)
 
-instance (Show v, Show k) => Show (Path k v) where
+instance {-# OVERLAPPABLE #-} (Show v, Show k) => Show (Path k v) where
   show (Path ks v) = (L.intercalate "/" $ map show ks) ++ ":" ++ show v
 
-instance Show v => Show (Path BS.ByteString v) where
+instance {-# OVERLAPPABLE #-} Show v => Show (Path BS.ByteString v) where
   show (Path ks v) = (L.intercalate "/" $ map B.prefix ks) ++ ":" ++ show v
 
 instance Functor (Path k) where

--- a/src/Database/Concelo/Protocol.hs
+++ b/src/Database/Concelo/Protocol.hs
@@ -100,7 +100,6 @@ import qualified Database.Concelo.Bytes as B
 import qualified Control.Lens as L
 import qualified Data.ByteString.Char8 as BS
 
-import Data.Functor ((<$>))
 import Prelude hiding (foldr)
 import Data.Foldable (Foldable(foldr))
 

--- a/src/Database/Concelo/Publisher.hs
+++ b/src/Database/Concelo/Publisher.hs
@@ -8,7 +8,6 @@ module Database.Concelo.Publisher
   , publisher ) where
 
 import Database.Concelo.Control (updateThenGet, get, patternFailure, set)
-import Data.Functor ((<$>))
 
 import qualified Database.Concelo.Trie as T
 import qualified Database.Concelo.Protocol as Pr

--- a/src/Database/Concelo/Regex.hs
+++ b/src/Database/Concelo/Regex.hs
@@ -13,7 +13,6 @@ import Database.Concelo.Control (noParse, ParseState(parseString), endOfStream,
                                  endOfInput, oneOrMore, get)
 
 import Data.Maybe (isJust)
-import Data.Functor ((<$>))
 
 import qualified Control.Monad.Except as E
 import qualified Data.ByteString.Char8 as BS

--- a/src/Database/Concelo/Relay.hs
+++ b/src/Database/Concelo/Relay.hs
@@ -20,7 +20,6 @@ import Database.Concelo.Control (set, get, getThenSet, updateThenGet,
 import Control.Monad (when)
 import Prelude hiding (mapM_, foldr)
 import Database.Concelo.Misc (foldM, mapM_)
-import Data.Functor ((<$>))
 import Data.Foldable (foldr)
 import Data.Maybe (isJust, fromJust)
 

--- a/src/Database/Concelo/Rules.hs
+++ b/src/Database/Concelo/Rules.hs
@@ -38,7 +38,6 @@ import Database.Concelo.Control (noParse, maybeToAction, stringLiteral,
 import Database.Concelo.Misc (null)
 import Control.Monad (liftM2, liftM3, foldM)
 import Data.Fixed (mod')
-import Data.Functor ((<$>))
 import Data.Foldable (foldr)
 
 import qualified Data.ByteString.Char8 as BS

--- a/src/Database/Concelo/Serializer.hs
+++ b/src/Database/Concelo/Serializer.hs
@@ -14,7 +14,6 @@ import Database.Concelo.Control (exception, get, set, with, patternFailure,
                                  update, getThenSet, eitherToAction, run)
 
 import Control.Monad (when)
-import Data.Functor ((<$>))
 import Database.Concelo.Misc (foldM)
 import Data.Maybe (isJust, isNothing, fromJust)
 

--- a/src/Database/Concelo/Subscriber.hs
+++ b/src/Database/Concelo/Subscriber.hs
@@ -32,7 +32,6 @@ import Database.Concelo.Control (patternFailure, badForest, missingChunks,
                                  set, get, update, updateM, getThenUpdate,
                                  exception, with)
 import Control.Monad (when)
-import Data.Functor ((<$>))
 import Data.Foldable (foldr)
 import Prelude hiding (foldr, mapM_, null)
 import Database.Concelo.Misc (foldM, mapM_, null)

--- a/src/Database/Concelo/SyncTree.hs
+++ b/src/Database/Concelo/SyncTree.hs
@@ -23,8 +23,7 @@ module Database.Concelo.SyncTree
 import Database.Concelo.Control (get, patternFailure, with, set, bsShow,
                                  maybeToAction, eitherToAction, run, bsRead,
                                  exception)
-import Control.Applicative ((<|>), (<*>))
-import Data.Functor ((<$>))
+import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Database.Concelo.Misc (foldM, forM_, mapM_, length)
 import Data.Foldable (toList, foldr)

--- a/src/Database/Concelo/Trie.hs
+++ b/src/Database/Concelo/Trie.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 module Database.Concelo.Trie
   ( Trie()
   , trie
@@ -43,17 +42,14 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Database.Concelo.VTrie as V
 import qualified Database.Concelo.TrieLike as TL
 import Prelude hiding (foldr)
-import Control.Applicative ((<*>), pure)
-import Data.Functor ((<$>))
 import Data.Foldable (Foldable(foldr))
-import Data.Traversable (Traversable(traverse))
 
 newtype Trie k v = Trie { run :: V.VTrie k v } deriving (Eq)
 
-instance (Show k, Show v) => Show (Trie k v) where
+instance {-# OVERLAPPABLE #-} (Show k, Show v) => Show (Trie k v) where
   show = show . run
 
-instance Show v => Show (Trie BS.ByteString v) where
+instance {-# OVERLAPPABLE #-} Show v => Show (Trie BS.ByteString v) where
   show = show . run
 
 instance Ord k => Functor (Trie k) where

--- a/src/Database/Concelo/VMap.hs
+++ b/src/Database/Concelo/VMap.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 module Database.Concelo.VMap
   ( VMap()
   , empty
@@ -31,17 +30,16 @@ import qualified Data.ByteString.Base16 as B16
 import qualified Data.Tree.RBTree as T
 import qualified Control.Lens as L
 import Data.Maybe (fromJust)
-import Data.Functor ((<$>))
 import Control.Applicative ((<|>))
 import Prelude hiding (foldr)
 import Data.Foldable (Foldable(foldr))
 
 newtype VMap k v = VMap { run :: T.RBTree (Cell k v) }
 
-instance (Show k, Show v) => Show (VMap k v) where
+instance {-# OVERLAPPABLE #-} (Show k, Show v) => Show (VMap k v) where
   show = show . pairs
 
-instance Show v => Show (VMap BS.ByteString v) where
+instance {-# OVERLAPPABLE #-} Show v => Show (VMap BS.ByteString v) where
   show = show . fmap (\(k,v) -> (B16.encode $ BS.take 4 k, v)) . pairs
 
 instance Ord k => Functor (VMap k) where

--- a/src/Database/Concelo/VTrie.hs
+++ b/src/Database/Concelo/VTrie.hs
@@ -52,7 +52,6 @@ import qualified Control.Lens as L
 import Database.Concelo.Misc (null)
 import Data.Maybe (isNothing, isJust, fromMaybe)
 import Control.Applicative ((<|>))
-import Data.Functor ((<$>))
 import Prelude hiding (foldr, null)
 import Data.Foldable (Foldable(foldr))
 

--- a/src/Database/Concelo/VTrie.hs
+++ b/src/Database/Concelo/VTrie.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverlappingInstances #-}
 module Database.Concelo.VTrie
   ( VTrie()
   , isEmpty
@@ -65,10 +64,10 @@ data VTrie k v = VTrie { getVTrieVersioned :: Maybe (Versioned v)
 
 vtrieVersioned = L.lens getVTrieVersioned (\x v -> x { getVTrieVersioned = v })
 
-instance (Show k, Show v) => Show (VTrie k v) where
+instance {-# OVERLAPPABLE #-} (Show k, Show v) => Show (VTrie k v) where
   show = show . paths
 
-instance Show v => Show (VTrie BS.ByteString v) where
+instance {-# OVERLAPPABLE #-} Show v => Show (VTrie BS.ByteString v) where
   show = show . paths
 
 instance (Eq k, Eq v) => Eq (VTrie k v) where

--- a/test/Data/Tree/RBTests.hs
+++ b/test/Data/Tree/RBTests.hs
@@ -3,7 +3,6 @@
 module Data.Tree.RBTests
   ( runTests ) where
 
-import Data.Functor ((<$>))
 import Data.Tree.RBTree
 import Test.QuickCheck
 

--- a/test/Database/Concelo/Simulation.hs
+++ b/test/Database/Concelo/Simulation.hs
@@ -11,8 +11,6 @@ import Database.Concelo.Control (get, run, exec, update, Exception(Success),
                                  exception, eval, patternFailure, bsShow)
 
 import Data.List (inits)
-import Data.Functor ((<$>))
-import Control.Applicative ((<*>))
 import Debug.Trace
 
 import qualified Database.Concelo.VTrie as VT


### PR DESCRIPTION
First, I changed the Build Notes until they worked without errors on my mac.  I'm mostly just banging on my keyboard until it works, so the updated instructions may not be what you want - but at least the tests run fine for me.

With the original instructions, I was seeing the following error:

```
cabal: At least the following dependencies are missing:
QuickCheck >=2.8.2, tf-random >=0.5
```

Then, I went and fixed two classes of warnings that were causing the build to fail for me (because of `-Werror`).  I'm using ghc 7.10.3, if that tells you anything.
